### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:alpine
+
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+    ffmpeg \
+    libheif \
+    libheif-dev \
+    bash \
+    git \
+    pkgconfig \
+    build-base
+
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x build.sh
+
+RUN ./build.sh
+
+ENTRYPOINT ["./govd"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ cd govd
 sh build.sh
 ```
 
+## Installation with Docker
+first build the image using the dockerfile
+
+```bash
+docker build -t govd-bot .
+```
+
+then edit the .env file and match the DB properties with the MariaDB service environment variables in the docker-compose.yml file and run
+
+```bash
+docker compose up -d
+```
+
 ## cookies
 
 some extractors require cookies for download. to add your cookies, just insert a txt file in cookies folder (netscape format)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,25 @@
+services:
+  govd-bot:
+    image: govd-bot
+    restart: unless-stopped
+    networks:
+      - govd-network
+    env_file:
+      - .env
+    depends_on:
+      - db    
+
+  db:
+    image: mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: govd
+      MYSQL_USER: govd
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: example
+    networks:
+      - govd-network
+
+networks:
+  govd-network:
+    driver: bridge


### PR DESCRIPTION
I added a first docker support for the telegram bot.

The current issue with this initial support is that the govd service restarts while MariaDB is starting up. As a result, the bot service logs an error indicating it cannot connect to the database during this period. So, sometimes the bot service needs to be manually stopped and restarted.

I also edited the README with the commands to start the services.
