### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,62 @@
-FROM golang:alpine
+FROM golang:bookworm
 
-RUN apk update && \
-    apk upgrade && \
-    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-    ffmpeg \
-    libheif \
-    libheif-dev \
+# Install dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
     bash \
     git \
-    pkgconfig \
-    build-base
+    pkg-config \
+    build-essential \
+    tar \
+    wget \
+    xz-utils \
+    gcc \
+    cmake \
+    libjpeg-dev \
+    libpng-dev \
+    libtiff-dev \
+    libgif-dev \
+    libde265-dev \
+    libaom-dev \
+    libx264-dev \
+    libx265-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* 
 
+# download, build and install libheif-1.19.7
+RUN wget https://github.com/strukturag/libheif/releases/download/v1.19.7/libheif-1.19.7.tar.gz && \
+    tar -xzvf libheif-1.19.7.tar.gz && \
+    cd libheif-1.19.7 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
+
+# create directories for ffmpeg
+RUN mkdir -p /usr/local/bin /usr/local/lib/pkgconfig/ /usr/local/lib/ /usr/local/include
+
+# download and extract FFmpeg 7.0
+RUN wget -O ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-04-30-12-51/ffmpeg-N-115029-g08781ebe1a-linux64-gpl-shared.tar.xz
+    
+RUN tar -xf ffmpeg.tar.xz
+
+RUN rm ffmpeg.tar.xz && \
+    cp -rv ffmpeg-N-115029-g08781ebe1a-linux64-gpl-shared/bin/* /usr/local/bin/ && \
+    cp -rv ffmpeg-N-115029-g08781ebe1a-linux64-gpl-shared/lib/* /usr/local/lib/ && \
+    cp -rv ffmpeg-N-115029-g08781ebe1a-linux64-gpl-shared/include/* /usr/local/include/ && \
+    cp -rv ffmpeg-N-115029-g08781ebe1a-linux64-gpl-shared/lib/pkgconfig/* /usr/local/lib/pkgconfig/ && \
+    ldconfig /usr/local
+
+# set env for building
+ENV CGO_CFLAGS="-I/usr/local/include"
+ENV CGO_LDFLAGS="-L/usr/local/lib"  
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
+    
 WORKDIR /bot
 
-RUN mkdir downloads
+RUN mkdir -p downloads
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ _this method only works on linux and macos, if you want to build the bot on wind
     ```
 
 ## docker (recommended)
-> [!WARNING]  
-> this method is currently not working due to a wrong version of the libav (ffmpeg) library in the docker image. feel free to open a PR if you can fix it.
 
 1. build the image using the dockerfile:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,22 +1,24 @@
 services:
   govd-bot:
-    image: govd-bot
+    image: govd-bot-dev
+    container_name: govd-bot-dev
     restart: unless-stopped
     networks:
       - govd-network
     env_file:
       - .env
     depends_on:
-      - db    
+      - db   
 
   db:
-    image: mysql
+    image: mariadb:latest
+    container_name: mariadb
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: govd
-      MYSQL_USER: govd
-      MYSQL_PASSWORD: password
-      MYSQL_ROOT_PASSWORD: example
+      MARIADB_DATABASE: govd
+      MARIADB_USER: govd
+      MARIADB_PASSWORD: password
+      MARIADB_ROOT_PASSWORD: example
     networks:
       - govd-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   govd-bot:
-    image: govd-bot-dev
-    container_name: govd-bot-dev
+    image: govd-bot
+    container_name: govd-bot
     restart: unless-stopped
     networks:
       - govd-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     depends_on:
-      - db   
+      - db
 
   db:
     image: mariadb:latest


### PR DESCRIPTION
i fixed the docker implementation of the bot.
I changed linux distro from alpine to debian that has lesser dependency issue, other than libheif.
The dockerfiles build that packages becuase there is not the 1.19.7 version in the debian main repo, and installing it by sid repo is risky.
The ffmpeg library is from your older dockerfile github repo, but I chose an exact version of it, the 7.0.
I also changed DataBase to mariadb on the docker compose.
The building of the dockerfile is the same as the older one, so don't need to update readme instructions.

