### PR TITLE
Make default settings configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ CAPTION_HEADER="<b>this is an header</b>"
 CAPTION_DESCRIPTION="description: <i>{{text}}</i>"
 
 # default group settings
-DEFAULT_CAPTIONS=false
-DEFAULT_SILENT=false
+DEFAULT_ENABLE_CAPTIONS=false
+DEFAULT_ENABLE_SILENT=false
 DEFAULT_ENABLE_NSFW=false
 DEFAULT_MEDIA_LIMIT=10

--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ LOG_FILE=false
 # WHITELIST=id1,id2,id3
 CAPTION_HEADER="<b>this is an header</b>"
 CAPTION_DESCRIPTION="description: <i>{{text}}</i>"
+
+# default group settings
+DEFAULT_CAPTIONS=false
+DEFAULT_SILENT=false
+DEFAULT_ENABLE_NSFW=false
+DEFAULT_MEDIA_LIMIT=10

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -3,27 +3,6 @@ the `config.yaml` file allows you to set custom options for each extractor. this
 > [!NOTE]
 > this configuration will override the global configuration. this is useful in case you want to set a global proxy in the `.env` file and then override it for specific extractors in the `config.yaml` file.
 
-# environment variables
-
-## default group settings
-these environment variables control the default settings for new groups when they first use the bot:
-
-* `DEFAULT_CAPTIONS`: whether captions are enabled by default for new groups (true/false, default: false)
-* `DEFAULT_SILENT`: whether silent mode is enabled by default for new groups (true/false, default: false)
-* `DEFAULT_ENABLE_NSFW`: whether NSFW content is enabled by default for new groups (true/false, default: false)
-* `DEFAULT_MEDIA_LIMIT`: default media group limit for new groups (1-20, default: 10)
-
-example:
-```bash
-DEFAULT_CAPTIONS=true
-DEFAULT_SILENT=false
-DEFAULT_ENABLE_NSFW=false
-DEFAULT_MEDIA_LIMIT=5
-```
-
-> [!NOTE]
-> these settings only affect new groups. existing groups will keep their current settings and can still override these defaults using bot commands like `/captions`, `/silent`, `/nsfw`, and `/limit`.
-
 # structure
 the file uses yaml format. each top-level key is the name of an extractor. under each extractor, you can define options supported by that extractor, for example:
 ```yaml

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -3,6 +3,27 @@ the `config.yaml` file allows you to set custom options for each extractor. this
 > [!NOTE]
 > this configuration will override the global configuration. this is useful in case you want to set a global proxy in the `.env` file and then override it for specific extractors in the `config.yaml` file.
 
+# environment variables
+
+## default group settings
+these environment variables control the default settings for new groups when they first use the bot:
+
+* `DEFAULT_CAPTIONS`: whether captions are enabled by default for new groups (true/false, default: false)
+* `DEFAULT_SILENT`: whether silent mode is enabled by default for new groups (true/false, default: false)
+* `DEFAULT_ENABLE_NSFW`: whether NSFW content is enabled by default for new groups (true/false, default: false)
+* `DEFAULT_MEDIA_LIMIT`: default media group limit for new groups (1-20, default: 10)
+
+example:
+```bash
+DEFAULT_CAPTIONS=true
+DEFAULT_SILENT=false
+DEFAULT_ENABLE_NSFW=false
+DEFAULT_MEDIA_LIMIT=5
+```
+
+> [!NOTE]
+> these settings only affect new groups. existing groups will keep their current settings and can still override these defaults using bot commands like `/captions`, `/silent`, `/nsfw`, and `/limit`.
+
 # structure
 the file uses yaml format. each top-level key is the name of an extractor. under each extractor, you can define options supported by that extractor, for example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ you can configure the bot using the `.env` file. here are the available options:
 | HTTPS_PROXY  | https proxy       | none _(disabled)_  |
 | NO_PROXY     | no proxy domains  | none _(disabled)_  |
 
+## default settings
+configure default settings for groups. Group admins can override these settings by using commands.
+| variable                | description                                 | default                             |
+|-------------------------|---------------------------------------------|-------------------------------------|
+| DEFAULT_ENABLE_CAPTIONS | show original captions on messages          | false                               |
+| DEFAULT_ENABLE_SILENT   | omit error messages in groups (silent fail) | false                               |
+| DEFAULT_ENABLE_NSFW     | enable nsfw content in groups               | false                               |
+| DEFAULT_MEDIA_LIMIT     | max media files in a single message         | 10                                  |
+
 ## other
 
 | variable            | description                               | default                             |

--- a/config/env.go
+++ b/config/env.go
@@ -141,6 +141,46 @@ func LoadEnv() error {
 	if value := os.Getenv("CAPTION_DESCRIPTION"); value != "" {
 		Env.CaptionDescription = value
 	}
+	if value := os.Getenv("DEFAULT_CAPTIONS"); value != "" {
+		if defaultCaptions, err := strconv.ParseBool(value); err == nil {
+			Env.DefaultCaptions = defaultCaptions
+		} else {
+			zap.S().Fatal("DEFAULT_CAPTIONS env is not a valid boolean")
+		}
+	} else {
+		zap.S().Warnf("DEFAULT_CAPTIONS is not set, using default %t", Env.DefaultCaptions)
+	}
+	if value := os.Getenv("DEFAULT_SILENT"); value != "" {
+		if defaultSilent, err := strconv.ParseBool(value); err == nil {
+			Env.DefaultSilent = defaultSilent
+		} else {
+			zap.S().Fatal("DEFAULT_SILENT env is not a valid boolean")
+		}
+	} else {
+		zap.S().Warnf("DEFAULT_SILENT is not set, using default %t", Env.DefaultSilent)
+	}
+	if value := os.Getenv("DEFAULT_ENABLE_NSFW"); value != "" {
+		if defaultNSFW, err := strconv.ParseBool(value); err == nil {
+			Env.DefaultNSFW = defaultNSFW
+		} else {
+			zap.S().Fatal("DEFAULT_ENABLE_NSFW env is not a valid boolean")
+		}
+	} else {
+		zap.S().Warnf("DEFAULT_ENABLE_NSFW is not set, using default %t", Env.DefaultNSFW)
+	}
+	if value := os.Getenv("DEFAULT_MEDIA_LIMIT"); value != "" {
+		if defaultMediaLimit, err := strconv.Atoi(value); err == nil {
+			if defaultMediaLimit >= 1 && defaultMediaLimit <= 20 {
+				Env.DefaultMediaGroupLimit = defaultMediaLimit
+			} else {
+				zap.S().Fatal("DEFAULT_MEDIA_LIMIT must be between 1 and 20")
+			}
+		} else {
+			zap.S().Fatal("DEFAULT_MEDIA_LIMIT env is not a valid integer")
+		}
+	} else {
+		zap.S().Warnf("DEFAULT_MEDIA_LIMIT is not set, using default %d", Env.DefaultMediaGroupLimit)
+	}
 	return nil
 }
 
@@ -164,5 +204,11 @@ func GetDefaultConfig() *models.EnvConfig {
 
 		CaptionHeader:      "<a href='{{url}}'>source</a> - @govd_bot",
 		CaptionDescription: "<blockquote expandable>{{text}}</blockquote>",
+
+		// Default group settings
+		DefaultCaptions:        false,
+		DefaultSilent:          false,
+		DefaultNSFW:            false,
+		DefaultMediaGroupLimit: 10,
 	}
 }

--- a/config/env.go
+++ b/config/env.go
@@ -141,23 +141,19 @@ func LoadEnv() error {
 	if value := os.Getenv("CAPTION_DESCRIPTION"); value != "" {
 		Env.CaptionDescription = value
 	}
-	if value := os.Getenv("DEFAULT_CAPTIONS"); value != "" {
+	if value := os.Getenv("DEFAULT_ENABLE_CAPTIONS"); value != "" {
 		if defaultCaptions, err := strconv.ParseBool(value); err == nil {
 			Env.DefaultCaptions = defaultCaptions
 		} else {
-			zap.S().Fatal("DEFAULT_CAPTIONS env is not a valid boolean")
+			zap.S().Fatal("DEFAULT_ENABLE_CAPTIONS env is not a valid boolean")
 		}
-	} else {
-		zap.S().Warnf("DEFAULT_CAPTIONS is not set, using default %t", Env.DefaultCaptions)
 	}
-	if value := os.Getenv("DEFAULT_SILENT"); value != "" {
+	if value := os.Getenv("DEFAULT_ENABLE_SILENT"); value != "" {
 		if defaultSilent, err := strconv.ParseBool(value); err == nil {
 			Env.DefaultSilent = defaultSilent
 		} else {
-			zap.S().Fatal("DEFAULT_SILENT env is not a valid boolean")
+			zap.S().Fatal("DEFAULT_ENABLE_SILENT env is not a valid boolean")
 		}
-	} else {
-		zap.S().Warnf("DEFAULT_SILENT is not set, using default %t", Env.DefaultSilent)
 	}
 	if value := os.Getenv("DEFAULT_ENABLE_NSFW"); value != "" {
 		if defaultNSFW, err := strconv.ParseBool(value); err == nil {
@@ -165,8 +161,6 @@ func LoadEnv() error {
 		} else {
 			zap.S().Fatal("DEFAULT_ENABLE_NSFW env is not a valid boolean")
 		}
-	} else {
-		zap.S().Warnf("DEFAULT_ENABLE_NSFW is not set, using default %t", Env.DefaultNSFW)
 	}
 	if value := os.Getenv("DEFAULT_MEDIA_LIMIT"); value != "" {
 		if defaultMediaLimit, err := strconv.Atoi(value); err == nil {
@@ -178,8 +172,6 @@ func LoadEnv() error {
 		} else {
 			zap.S().Fatal("DEFAULT_MEDIA_LIMIT env is not a valid integer")
 		}
-	} else {
-		zap.S().Warnf("DEFAULT_MEDIA_LIMIT is not set, using default %d", Env.DefaultMediaGroupLimit)
 	}
 	return nil
 }

--- a/database/settings.go
+++ b/database/settings.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"github.com/govdbot/govd/config"
 	"github.com/govdbot/govd/models"
 )
 
@@ -12,7 +13,13 @@ func GetGroupSettings(
 		Where(&models.GroupSettings{
 			ChatID: chatID,
 		}).
-		FirstOrCreate(&groupSettings).
+		FirstOrCreate(&groupSettings, &models.GroupSettings{
+			ChatID:          chatID,
+			Captions:        &config.Env.DefaultCaptions,
+			Silent:          &config.Env.DefaultSilent,
+			NSFW:            &config.Env.DefaultNSFW,
+			MediaGroupLimit: config.Env.DefaultMediaGroupLimit,
+		}).
 		Error
 	if err != nil {
 		return nil, err

--- a/models/config.go
+++ b/models/config.go
@@ -30,6 +30,12 @@ type EnvConfig struct {
 
 	CaptionHeader      string
 	CaptionDescription string
+
+	// Default group settings
+	DefaultCaptions        bool
+	DefaultSilent          bool
+	DefaultNSFW            bool
+	DefaultMediaGroupLimit int
 }
 
 type ExtractorConfig struct {


### PR DESCRIPTION
This PR adds support for configuring global default values for group settings (captions, silent mode, NSFW, and media group limit) through environment variables, while maintaining backward compatibility and per-group override functionality.

**New Environment Variables**
`DEFAULT_CAPTIONS` - Set default captions enabled/disabled for new groups (boolean, default: false)
`DEFAULT_SILENT` - Set default silent mode for new groups (boolean, default: false)
`DEFAULT_ENABLE_NSFW` - Set default NSFW content access for new groups (boolean, default: false)
`DEFAULT_MEDIA_LIMIT` - Set default media group limit for new groups (1-20, default: 10)