### PR TITLE
Add MAU badge for @govd_bot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://github.com/govdbot/govd/forks"><img src="https://img.shields.io/github/forks/govdbot/govd?style=flat-square" alt="forks"></a>
   <img src="https://img.shields.io/badge/docker-ready-blue?style=flat-square" alt="docker">
   <a href="https://t.me/govd_bot"><img src="https://img.shields.io/badge/telegram-@govd__bot-2CA5E0?style=flat-square&logo=telegram" alt="telegram"></a>
+  <a href="https://tgbotmau.quoi.dev/?bot=govd_bot" target="_blank"><img alt="@govd_bot MAU" title="@govd_bot MAU" src="https://tgbotmau.quoi.dev/api/bot/govd_bot/mau/badge?style=flat-square"></a>
 </p>
 
 ## features


### PR DESCRIPTION
I believe it's nice to have MAU badge in popular OpenSource bot projects to flex about huge user base.
I discovered that there're no ready to use Telegram-counted (the only real source of truth) MAU badge generators, so I've created my own small service.
As a bonus, it tracks MAU changement history over time and displays it by clicking.

I've used badge style that fits your existing badges in README, but you can customize badge style on your own using https://tgbotmau.quoi.dev/.

Feel free to reach me out in case of need of any adjustments.