### PR TITLE
Add {{mention}} variable for user attribution in captions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ DEFAULT_ENABLE_SILENT=false
 DEFAULT_ENABLE_NSFW=false
 DEFAULT_MEDIA_ALBUM_LIMIT=10
 DEFAULT_LANGUAGE=en
+DEFAULT_DELETE_LINKS=false
 
 # other
 REPO_URL=https://github.com/govdbot/govd
@@ -38,7 +39,7 @@ PROFILER_PORT=6060 # default pprof port
 METRICS_PORT=8080 # default prometheus metrics port
 LOG_LEVEL=info
 WHITELIST=id1,id2,id3
-CAPTIONS_HEADER="<a href='{{url}}'>source</a> - @{{username}}"
+CAPTIONS_HEADER="{{mention}}:\n<a href='{{url}}'>source</a> - @{{username}}"
 CAPTIONS_DESCRIPTION="<blockquote expandable>{{text}}</blockquote>"
 ADMINS=id1,id2
 AUTOMATIC_LANGUAGE_DETECTION=true

--- a/internal/core/inline.go
+++ b/internal/core/inline.go
@@ -89,6 +89,7 @@ func HandleInlineResultTask(
 		taskResult.Media,
 		bot.Username,
 		extractorCtx.Chat.Captions,
+		ctx.EffectiveUser,
 	)
 
 	err = SendInlineFormats(

--- a/internal/core/main.go
+++ b/internal/core/main.go
@@ -34,6 +34,7 @@ func HandleDownloadTask(
 		taskResult.Media,
 		bot.Username,
 		extractorCtx.Chat.Captions,
+		ctx.EffectiveUser,
 	)
 
 	_, err = SendFormats(

--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/govdbot/govd/internal/util"
 	"github.com/govdbot/govd/internal/util/download"
 	"github.com/govdbot/govd/internal/util/libav"
+	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
 var ErrNoMedia = errors.New("no media found")
@@ -86,21 +87,41 @@ func insertVideoInfo(format *models.MediaFormat, filePath string) {
 	format.Height = height
 }
 
-func formatCaption(media *models.Media, username string, isEnabled bool) string {
+func formatCaption(media *models.Media, botUsername string, isEnabled bool, user *gotgbot.User) string {
 	caption := media.Caption
 	if len(caption) > 600 {
 		caption = caption[:600] + "..."
 	}
+
 	formatText := func(s string) string {
-		s = strings.ReplaceAll(s, "{{username}}", username)
+		var displayName string
+		if user.Username != "" {
+			displayName = "@" + user.Username
+		} else {
+			displayName = user.FirstName
+			if user.LastName != "" {
+				displayName += " " + user.LastName
+			}
+		}
+
+		// Wrap the name/username in a permanent ID link to handle username changes
+		mention := fmt.Sprintf("<a href=\"tg://user?id=%d\">%s</a>", user.Id, displayName)
+
+		s = strings.ReplaceAll(s, "{{username}}", botUsername)
 		s = strings.ReplaceAll(s, "{{url}}", media.ContentURL)
 		s = strings.ReplaceAll(s, "{{text}}", util.Unquote(caption))
+		s = strings.ReplaceAll(s, "{{mention}}", mention)
 		return s
 	}
+
 	var description string
 	header := formatText(config.Env.CaptionsHeader)
 	if isEnabled && caption != "" {
 		description = formatText(config.Env.CaptionsDescription)
+	}
+
+	if description == "" {
+		return header
 	}
 	return header + "\n" + description
 }


### PR DESCRIPTION
This PR adds the `{{mention}}` variable to caption templates.

It is specifically useful when `DEFAULT_DELETE_LINKS` is enabled, as it allows the bot to tag the original sender in the new message's header, keeping the conversation traceable after the source link is deleted.

Note:
I used a clanker to make the code for this PR. To me, it seems OK since it compiles and works. I don't know Go.